### PR TITLE
Require auto-complete for byte-compilation

### DIFF
--- a/jquery-doc.el
+++ b/jquery-doc.el
@@ -25,6 +25,9 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'auto-complete))
+
 (require 'jquery-doc-data)
 
 ;; xml helpers


### PR DESCRIPTION
If byte-compiling is performed on jquery-doc without auto-complete, the byte-compiled output will be unusable because of the use of macros..
This manifests itself most easily when building in a child process without much loaded.
