### PR TITLE
New jquery-doc-fetch-and-generate-data command

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -16,3 +16,11 @@ Installation
 (require 'jquery-doc)
 (add-hook 'js2-mode-hook 'jquery-doc-setup)
 ```
+
+Updating API data
+=================
+
+If you'd like to update the API data to the latest version available
+you can use the `jquery-doc-fetch-and-generate-data` command.
+
+Warning: it may take a few seconds to parse all the data.


### PR DESCRIPTION
This new command is intended to replace the update-doc-data Makefile
step _and_ make it easier for users to update the jQuery API data
directly from Emacs.

New var:
- jquery-doc-api-xml-url

New functions:
- jquery-doc-fetch-and-generate-data
- jquery-doc-ensure-api-xml
