### PR TITLE
Autoload `jquery-doc-setup`

### DIFF
--- a/jquery-doc.el
+++ b/jquery-doc.el
@@ -415,7 +415,7 @@ Optional argument JQUERY-METHOD method-name."
                   buf))))
 
 ;; common
-
+;;;###autoload
 (defun jquery-doc-setup ()
   (when (boundp 'ac-sources)
     (pushnew 'ac-source-jquery ac-sources))


### PR DESCRIPTION
Without this change, one can't call `jquery-doc-setup` without loading the full plugin. In the recommended setting, for example, the plug-in will be loaded regardless of whether a js file is actually loaded.
